### PR TITLE
fix: set timers to update buffer state

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ require'marks'.setup {
   builtin_marks = { ".", "<", ">", "^" }, -- which builtin marks to show. default {}
   cyclic = true, -- whether movements cycle back to the beginning/end of buffer. default true
   force_write_shada = false, -- whether the shada file is updated after modifying uppercase marks. default false
+  refresH_interval = 250, -- how often (in ms) to redraw signs/recompute mark positions. 
+                          -- higher values will have better performance but may cause visual lag, 
+                          -- while lower values may cause performance penalties.
   bookmark_0 = { -- marks.nvim allows you to configure up to 10 bookmark groups, each with its own sign/virttext
     sign = "⚑",
     virt_text = "hello world"

--- a/doc/marks-nvim.txt
+++ b/doc/marks-nvim.txt
@@ -101,6 +101,16 @@ plugin. The following options are defined:
     This option can be destructive and should be set only after reading more
     about the shada file.
 
+                                                      *marks-refresh_interval*
+  refresh_interval: integer
+    (default 150)
+
+    How often (in ms) marks.nvim should update the marks list and recompute
+    mark positions/redraw signs. Lower values means that mark positions and
+    signs will refresh much quicker, but may incur a higher performance
+    penalty, whereas higher values may result in better performance, but may
+    also cause noticable lag in signs updating.
+
   bookmark_[0-9]: table                              *marks-bookmark_config*
     (default {})
 

--- a/lua/marks/bookmark.lua
+++ b/lua/marks/bookmark.lua
@@ -11,14 +11,16 @@ local Bookmarks = {}
 -- each mark is represented by a table with the following keys:
 --  buf, line, col, sign_id, extmark_id
 --
-local function group_under_cursor(group, bufnr, pos)
+local function group_under_cursor(groups, bufnr, pos)
   local bufnr = bufnr or vim.api.nvim_get_current_buf()
   local pos = pos or vim.fn.getpos(".")
 
-  if group.marks[bufnr] and group.marks[bufnr][pos[2]] then
-    return true
+  for group_nr, group in pairs(groups) do
+    if group.marks[bufnr] and group.marks[bufnr][pos[2]] then
+      return group_nr
+    end
   end
-  return false
+  return nil
 end
 
 local function flatten(marks)
@@ -103,35 +105,13 @@ function Bookmarks:delete_mark(group_nr, bufnr, lnum)
   group.marks[bufnr][lnum] = nil
 end
 
-function Bookmarks:validate_bookmarks(group_nr, bufnr)
-  local bufnr = bufnr or vim.api.nvim_get_current_buf()
-  if not self.groups[group_nr] or not self.groups[group_nr].marks[bufnr] then
-    return
-  end
-  
-  local buf_marks = self.groups[group_nr].marks[bufnr]
-  for _, mark in pairs(vim.tbl_values(buf_marks)) do
-    local line = vim.api.nvim_buf_get_extmark_by_id(bufnr, self.groups[group_nr].ns,
-        mark.extmark_id, {})[1]
-    if line + 1 ~= mark.line then
-      buf_marks[line + 1] = mark
-      buf_marks[mark.line] = nil
-      buf_marks[line + 1].line = line + 1
-    end
-  end
-end
-
 function Bookmarks:delete_mark_cursor()
   local bufnr = vim.api.nvim_get_current_buf()
   local pos = vim.fn.getpos(".")
 
-  local group_nr
-  for num, group in pairs(self.groups) do
-    self:validate_bookmarks(num, bufnr)
-    if group_under_cursor(group, bufnr, pos) then
-      group_nr = num
-      break
-    end
+  local group_nr = group_under_cursor(self.groups, bufnr, pos)
+  if not group_nr then
+    return
   end
 
   self:delete_mark(group_nr, bufnr, pos[2])
@@ -144,7 +124,6 @@ function Bookmarks:delete_all(group_nr)
   end
 
   for bufnr, buf_marks in pairs(group.marks) do
-    -- self:validate_bookmarks(group_nr, bufnr)
     for line, mark in pairs(buf_marks) do
       if mark.sign_id then
         utils.remove_sign(bufnr, mark.sign_id, "BookmarkSigns")
@@ -161,16 +140,7 @@ function Bookmarks:next(group_nr)
   local pos = vim.fn.getpos(".")
 
   if not group_nr then
-    for num, group in pairs(self.groups) do
-      print(num)
-      self:validate_bookmarks(num, bufnr)
-      if group_under_cursor(group, bufnr, pos) then
-        group_nr = num
-        break
-      end
-    end
-  else
-    self:validate_bookmarks(group_nr, bufnr)
+    group_nr = group_under_cursor(self.groups, bufnr, pos)
   end
 
   local group = self.groups[group_nr]
@@ -206,15 +176,7 @@ function Bookmarks:prev(group_nr)
   local pos = vim.fn.getpos(".")
 
   if not group_nr then
-    for num, group in pairs(self.groups) do
-      self:validate_bookmarks(num, bufnr)
-      if group_under_cursor(group, bufnr, pos) then
-        group_nr = num
-        break
-      end
-    end
-  else
-    self:validate_bookmarks(group_nr, bufnr)
+    group_nr = group_under_cursor(self.groups, bufnr, pos)
   end
 
   local group = self.groups[group_nr]
@@ -243,6 +205,34 @@ function Bookmarks:prev(group_nr)
     vim.cmd("silent b" .. prev.buf)
   end
   vim.fn.setpos(".", { 0, prev.line, prev.col, 0 })
+end
+
+function Bookmarks:refresh()
+  local bufnr = vim.api.nvim_get_current_buf()
+  local buf_marks
+
+  -- if we delete and undo really quickly, the extmark's position will be
+  -- the same, but the sign will no longer be there. so clear and restore all
+  -- signs.
+
+  utils.remove_buf_signs(bufnr, "BookmarkSigns")
+  for group_nr, group in pairs(self.groups) do
+    buf_marks = group.marks[bufnr]
+    if not buf_marks then
+      return
+    end
+    for _, mark in pairs(vim.tbl_values(buf_marks)) do
+      local line = vim.api.nvim_buf_get_extmark_by_id(bufnr, group.ns,
+          mark.extmark_id, {})[1]
+
+      if line + 1 ~= mark.line then
+        buf_marks[line + 1] = mark
+        buf_marks[mark.line] = nil
+        buf_marks[line + 1].line = line + 1
+      end
+      utils.add_sign(bufnr, group.sign, line + 1, mark.sign_id, "BookmarkSigns")
+    end
+  end
 end
 
 function Bookmarks:to_loclist(group_nr)


### PR DESCRIPTION
This ensures that the internal mark data structures and the actual
mark positions are synced up, meaning that moves, deletes, and
others work as expected. Also introduces a new config option
'refresh_interval', which controls how often the refresh operation
is called.

fixes #10 
fixes #12 