### PR TITLE
refactor: use `cursorhold` for redrawing instead of timers

### DIFF
--- a/lua/marks/init.lua
+++ b/lua/marks/init.lua
@@ -184,6 +184,7 @@ local function setup_autocommands()
   vim.cmd [[augroup Marks_autocmds
     autocmd!
     autocmd BufEnter * lua require'marks'.refresh(true)
+    autocmd CursorHold * lua require'marks'.refresh()
     autocmd BufDelete * lua require'marks'._on_delete()
   augroup end]]
 end
@@ -240,11 +241,6 @@ function M.setup(config)
     mark_priority[3] = config.sign_priority
     M.bookmark_state.priority = config.sign_priority
   end
-
-  local refresh_interval = utils.option_nil(config.refresh_interval, 150)
-
-  local timer = vim.loop.new_timer()
-  timer:start(0, refresh_interval, vim.schedule_wrap(M.refresh))
 end
 
 return M


### PR DESCRIPTION
haven't yet decided if this is the way to go, but might be a good stopgap until more timer fixes land in neovim core. ref #40 and #62 