### PR TITLE
Change BufEnter to BufReadPost, For invalid buffer id

### DIFF
--- a/lua/marks/init.lua
+++ b/lua/marks/init.lua
@@ -183,7 +183,7 @@ end
 local function setup_autocommands()
   vim.cmd [[augroup Marks_autocmds
     autocmd!
-    autocmd BufEnter * lua require'marks'.refresh(true)
+    autocmd BufReadPost * lua require'marks'.refresh(true)
     autocmd BufDelete * lua require'marks'._on_delete()
   augroup end]]
 end


### PR DESCRIPTION
**Question**

I have encountered the same error like #29, while I had config excluded_filetypes.My nvim's version is 0.7 stable.

**Solution**

So I read code about buffers, and I find the buffers's bufnr was wrong when create new Mark. So I change BuferEnter to BuferReadPost in init.lua.
I tried, and it works